### PR TITLE
ZB/setup.c: reinstate NT (non-transparent) rendering

### DIFF
--- a/ZB/awtmz.c
+++ b/ZB/awtmz.c
@@ -45,6 +45,8 @@ TrapezoidRenderCall TrapezoidRenderPIZ2TIA;
 TrapezoidRenderCall TrapezoidRenderPIZ2TIA_RGB_555;
 TrapezoidRenderCall TrapezoidRenderPIZ2TIA_RGB_888;
 
+TrapezoidRenderCall TrapezoidRenderPIZ2TIANT;
+
 static inline void TriangleRender_Generic_AWTMI(struct temp_vertex_fixed *a, struct temp_vertex_fixed *b,
                                   struct temp_vertex_fixed *c, br_boolean use_z_buffer, br_uint_32 bpp,
                                   TrapezoidRenderCall trapezoid_render, br_boolean use_bump,
@@ -322,6 +324,12 @@ void BR_ASM_CALL TriangleRenderPIZ2TIA(struct temp_vertex_fixed *a, struct temp_
                                        struct temp_vertex_fixed *c)
 {
     TriangleRender_Generic_AWTMI(a, b, c, 1, 1, TrapezoidRenderPIZ2TIA, 0, 1);
+}
+
+void BR_ASM_CALL TriangleRenderPIZ2TIANT(struct temp_vertex_fixed *a, struct temp_vertex_fixed *b,
+                                         struct temp_vertex_fixed *c)
+{
+    TriangleRender_Generic_AWTMI(a, b, c, 1, 1, TrapezoidRenderPIZ2TIANT, 0, 1);
 }
 
 void BR_ASM_CALL TriangleRenderPIZ2TA(struct temp_vertex_fixed *a, struct temp_vertex_fixed *b,

--- a/ZB/zbiproto.h
+++ b/ZB/zbiproto.h
@@ -93,6 +93,8 @@ extern "C"
 
     void BR_ASM_CALL TriangleRenderPIZ2TIA(struct temp_vertex_fixed *a, struct temp_vertex_fixed *b,
                                            struct temp_vertex_fixed *c);
+    void BR_ASM_CALL TriangleRenderPIZ2TIANT(struct temp_vertex_fixed *a, struct temp_vertex_fixed *b,
+                                             struct temp_vertex_fixed *c);
     void BR_ASM_CALL TriangleRenderPIZ2TIA_RGB_555(struct temp_vertex_fixed *a, struct temp_vertex_fixed *b,
                                                    struct temp_vertex_fixed *c);
     void BR_ASM_CALL TriangleRenderPIZ2TIA_RGB_888(struct temp_vertex_fixed *a, struct temp_vertex_fixed *b,

--- a/ZB/zbsetup.c
+++ b/ZB/zbsetup.c
@@ -213,6 +213,31 @@ static struct zb_material_type mat_types_index_8[] = {
         CM_U | CM_V | CM_I,
     },
 
+    /* Special Non-Transparent Rendering. (Textures only - the rest have
+       transparency, but it doesn't really matter. */
+
+    {
+        IDENT("Texture mapped (linear) AWNT"),
+        MT_MASK_T | BR_MATF_LIGHT | BR_MATF_PRELIT, ZB_MATF_HAS_MAP,
+        BR_PMT_INDEX_8, 0, 0,
+        ZbRenderFaceGroup_FaceIV, TriangleRenderPIZ2TIANT, LineRenderPIZ2TI, PointRenderPIZ2TI,
+        CM_COORDS | CM_U | CM_V , CM_U | CM_V,
+    },
+    {
+        IDENT("Lit flat texture mapped (linear) AWNT"),
+        MT_MASK_T | BR_MATF_LIGHT, BR_MATF_LIGHT | ZB_MATF_HAS_MAP,
+        BR_PMT_INDEX_8, 0, 0,
+        ZbRenderFaceGroup_FaceIV, TriangleRenderPIZ2TIANT, LineRenderPIZ2TI, PointRenderPIZ2TI,
+        CM_COORDS | CM_U | CM_V | CM_I, CM_U | CM_V | CM_I,
+    },
+    {
+        IDENT("Lit smooth texture mapped (linear) AWNT"),
+        MT_MASK_T | BR_MATF_LIGHT, BR_MATF_SMOOTH | BR_MATF_LIGHT | ZB_MATF_HAS_MAP,
+        BR_PMT_INDEX_8, 0, 0,
+        ZbRenderFaceGroup, TriangleRenderPIZ2TIANT, LineRenderPIZ2TI, PointRenderPIZ2TI,
+        CM_COORDS | CM_U | CM_V | CM_I, CM_U | CM_V | CM_I,
+    },
+
     //	/*
     //	 * Arbitary width general texture mapping + decal
     //	 */


### PR DESCRIPTION
Commit 1263191 "Translate most of the assembly over to C (and extras)" introduced a regression when rendering some actor textures in 3DMM. Reinstate the NT (non-transparent) rendering to ensure that actors are rendered correctly once again.

Current head:

![bad2](https://github.com/user-attachments/assets/5e7e50bd-3fad-489d-94c1-13e9ba29e340)

With this fix:

![good2](https://github.com/user-attachments/assets/8440116c-994a-4156-8b29-be2e0d7428cf)
